### PR TITLE
Fix for ios9

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="nl.x-services.plugins.launchmyapp"
-        version="3.2.6">
+        version="3.2.7">
 
   <name>Custom URL scheme</name>
 
@@ -41,6 +41,14 @@
             <string>$URL_SCHEME</string>
             <string>gsd-$URL_SCHEME</string>
           </array>
+        </dict>
+      </array>
+    </config-file>
+    <config-file target="*-Info.plist" parent="NSAppTransportSecurity">
+      <array>
+        <dict>
+          <key>NSAllowsArbitraryLoads</key>
+          <true/>
         </dict>
       </array>
     </config-file>


### PR DESCRIPTION
In ios9, Apple by default supports App Transport Security in order to
improve the security of connections between an app and web services.
This change provides an exception to the requirement to have to have
the transport layer encrypted between the app and website.
